### PR TITLE
Add a-h/gemini to server list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Please contribute to this list to link to all the awesome gemini projects out th
 
 ## Servers
 - [Agate](https://github.com/mbrubeck/agate) (Rust) - a simple Gemini server for static files.
+- [a-h/gemini] (https://github.com/a-h/gemini) (Go) - Server for Linux, Mac, Raspberry Pi. Supports SNI for multiple domains on the same server, has Docker image.
 - [blizanci](https://github.com/mk270/blizanci) (Erlang) - a server designed primarily for robustness and security.
 - [Denoscuri](https://github.com/caranatar/denoscuri) (Typescript) - a simple Gemini server written using Deno and Typescript.
 - [Duckling proxy 🦆](https://portal.mozz.us/gemini/gemini.marmaladefoo.com/blog/31-Aug-2020_The_Duckling_Proxy.gmi) (Go) - a scheme-specific filtering proxy for Gemini clients to access the web.


### PR DESCRIPTION
Realised that my server was in the programming section. The programming tools are implemented as a complete server.