### PR TITLE
Add gmnhg / md2gmn

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Please contribute to this list to link to all the awesome gemini projects out th
 - [gemini-to-html](https://github.com/RangerMauve/gemini-to-html) (Node.js) - a JavaScript library for parsing Gemini pages, and for rendering them to HTML.
 - [gloggery](https://github.com/kconner/gloggery) (Go) - basic static site generator for blogs in Gemini.
 - [gmitohtml](https://gitlab.com/tslocum/gmitohtml) (Go) - a proxy that renders Gemini pages using HTML.
+- [gmnhg](https://git.tdem.in/tdemin/gmnhg) (Go) - renders a Hugo site to a Gemini site
+- [md2gmn](https://git.tdem.in/tdemin/gmnhg) (Go) - renders Markdown text to Gemini pages
 
 ## Web proxies
 - [Mozz.us portal](https://portal.mozz.us/gemini/gemini.circumlunar.space/)


### PR DESCRIPTION
[gmnhg][gmnhg] is a tool that converts Hugo sites to Gemini sites (live site run with it: `gemini://tdem.in`). [md2gmn][md2gmn] is a tool that renders Markdown to Gemini pages. Both are included in a single repo (as both are based on the same renderer implementation hosted in this repo), so same link for both.

[gmnhg]: https://git.tdem.in/tdemin/gmnhg/src/branch/develop/cmd/gmnhg
[md2gmn]: https://git.tdem.in/tdemin/gmnhg/src/branch/develop/cmd/md2gmn