### PR TITLE
Add official spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Repo mirrors:
 
 ## Gemini Specification 
 
-- [protocol](https://gitlab.com/gemini-specification/protocol)
-- [gemini-text](https://gitlab.com/gemini-specification/gemini-text)
+- [Official specification](https://gemini.circumlunar.space/docs/specification.gmi)
+- [protocol spec discussion and development](https://gitlab.com/gemini-specification/protocol)
+- [gemini-text spec discussion and development](https://gitlab.com/gemini-specification/gemini-text)
 
 ## Contents
 


### PR DESCRIPTION
The spec links you have on the README are to GitLab, where the in-progress specs are hosted. I think it's much more helpful to have a link to the actual official spec.

The layout I have now is kind of clumsy, feel to improve or let me know changes I can make.