### PR TITLE
added gemtext syntax highlighting for lite-xl

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Repo mirrors:
 - [gemini.nanorc](https://github.com/yzzyx-network/nanorc/blob/master/gemini.nanorc) - text/gemini syntax highlighting for nano.
 - [gemini.sublime-syntax](https://github.com/adiabatic/gemini.sublime-syntax) - text/gemini syntax highlighting for bat (and maybe Sublime Text).
 - [gemini.yml](https://github.com/zyedidia/micro/blob/master/runtime/syntax/gemini.yaml) - text/gemini syntax highlighting for micro.
+- [language_gmi](https://github.com/lite-xl/lite-xl-plugins/blob/master/plugins/language_gmi.lua) - gemtext syntax highlighting for lite-xl
 
 ## Web proxies
 - [Mozz.us portal](https://portal.mozz.us/gemini/gemini.circumlunar.space/)


### PR DESCRIPTION
what the title says, I wrote the gemtext syntax highlighting plugin for [lite-xl](https://github.com/lite-xl/lite-xl), and thought that it belongs here.