### PR TITLE
Adds an entry for the tildeverse gemini proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Repo mirrors:
 - [Vulpes proxy](https://proxy.vulpes.one/gemini/gemini.circumlunar.space/)
 - [koyu.space GemProxy](https://gemproxy.koyu.space)
 - [Wobbly](https://www.warmedal.se/~wobbly/)
+- [Tildeverse Gemini Proxy](https://gemini.tildeverse.org)
 
 ## Bots
 - [Fortune Teller Bot](https://github.com/t-900-a/gemini-fortune-bot) - Generates a fortune gmi file, gemlog/index.gmi, and atom.xml every time the bot is executed


### PR DESCRIPTION
Proxy uses a forked version of Wobbly as its base