### PR TITLE
Add gmi100 to list of terminal clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Repo mirrors:
 - [tinmop](https://www.autistici.org/interzona/tinmop.html) (Common Lisp) - opinionated Mastodon and Gemini client
 - [gplaces](https://github.com/dimkr/gplaces) (C) - command-driven, terminal based Gemini client in ~1K LOC of C.
 - [tgmi](https://framagit.org/apm04/tgmi) (python) - full-featured CLI terminal-based Gemini client
+- [gmi100](https://github.com/ir33k/gmi100) (C) - CLI Gemini client written in 100 lines of ANSI C.
 
 ### Graphical
 #### Cross-platform


### PR DESCRIPTION
I would like to propose this addition to list of terminal clients.

It is a small CLI client called `gmi100` I wrote in 100 lines of C as a challenge for myself and for fun. It's actually usable with features similar to other small Gemini clients.

https://github.com/ir33k/gmi100
![demo](https://github.com/kr1sp1n/awesome-gemini/assets/49790836/5cc92ecf-ed8b-4f45-b571-241cfab9a59e)


