### PR TITLE
Add gempost

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Repo mirrors:
 - [gem.git](https://git.sr.ht/~fkfd/git.gmi/) (Python) - git frontend CGI script.
 - [gemini_http](https://github.com/cyevgeniy/gemini_http) (Go) - simple tool for viewing gemini files that are placed on a http server.
 - [gemmit](https://github.com/t-900-a/gemmit) (Go) - social news aggregation and web content rating website for the gemini protocol.
+- [gempost](https://github.com/justlark/gempost) (Rust) - Simple static site generator for Gemini blogs.
 - [GemPress](https://git.sr.ht/~aprates/gempress) (C) - Yet another Gemini publishing framework with HTML and Atom support, written in Bash and Sugar-C.
 - [gemtexter](https://codeberg.org/snonux/gemtexter) (Bash) - Site generator and blog engine for Gemini. Generates Atom and Gemfeeds , and also does Gemtext to HTML and Markdown conversion.
 - [gloggery](https://github.com/kconner/gloggery) (Go) - basic static site generator for blogs in Gemini.


### PR DESCRIPTION
[gempost](https://github.com/justlark/gempost) (Rust) - Simple static site generator for Gemini blogs.