### PR TITLE
Mention Tripod blog engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Repo mirrors:
 - [β-Doku](https://github.com/YGGverse/bdoku) (PHP) - DokuWiki Satellite for Gemini Protocol
 - [KevaChat](https://github.com/kevachat/geminiapp) (PHP) - client/server Chat in Blockchain
 - [gemini-server-clj](https://github.com/aburd/gemini-server-clj) (Clojure) - simple gemini server for serving static files
+- [tripod](https://github.com/aartaka/tripod) (Common Lisp) - Polyglot blog engine serving Gemtext, Gopher, HTML, and plaintext
 
 ## Services
 - __gemini://warmedal.se/~antenna/__ - Geminispace aggregator


### PR DESCRIPTION
This adds a mention of Tripod, a polyglot blog engine serving Gemini among others.