### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Repo mirrors:
 - [Denoscuri](https://github.com/caranatar/denoscuri) (Typescript) - simple Gemini server written using Deno and Typescript.
 - [Dʒɛmɪni](https://sr.ht/~rwv/dezhemini/) (Racket) - server with features like SNI and CGI.
 - [Diamant](https://git.umaneti.net/diamant/) (Ruby) - simple Gemini server for static files.
-- [doc-server](https://github.com/doga/doc-server) (Deno/Typescript) - A Gemini server for serving JSDoc documentation. Built on the Kaksik library.
+- [doc-server](https://github.com/doga/doc-server) (Deno/Typescript) - A Gemini server for serving JSDoc documentation. Built on the `qgeminiserver` library.
 - [Doppio](https://github.com/bhavanki/doppio) (Java) - single-JAR Gemini server with CGI, authentication, and Atom feed support.
 - [Duckling proxy 🦆](https://portal.mozz.us/gemini/gemini.marmaladefoo.com/blog/31-Aug-2020_The_Duckling_Proxy.gmi) (Go) - scheme-specific filtering proxy for Gemini clients to access the web.
 - [Earl Server](https://github.com/mrletourneau/EarlServer) (Kotlin) - Gemini fileserver for the JVM.


### PR DESCRIPTION
The latest version of `doc-server` is built on the `qgeminiserver` library.